### PR TITLE
Add MCP config for GitHub Actions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,7 +50,10 @@ jobs:
           assignee_trigger: "claude-bot"
           
           # Optional: Allow Claude to run specific commands
-          allowed_tools: "Bash,Read,Write,Edit,MultiEdit,LS,Glob,Grep,Task,WebFetch,TodoRead,TodoWrite,NotebookRead,NotebookEdit"
+          allowed_tools: |
+            Bash,Read,Write,Edit,MultiEdit,LS,Glob,Grep,Task,WebFetch,TodoRead,TodoWrite,NotebookRead,NotebookEdit,
+            mcp__playwright__*,mcp__typescript__*,mcp__o3__o3-search,mcp__context7__resolve-library-id,mcp__context7__get-library-docs
+          mcp_config: ./.mcp.json
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           
           # Optional: Custom environment variables for Claude

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,26 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest", "--config", "${{ github.workspace }}/setup/playwright-config.json"]
+    },
+    "typescript": {
+      "command": "npx",
+      "args": ["-y", "@mizchi/lsmcp", "--language=typescript"]
+    },
+    "o3": {
+      "command": "npx",
+      "args": ["o3-search-mcp"],
+      "env": {
+        "OPENAI_API_KEY": "${{ secrets.OPENAI_API_KEY }}",
+        "SEARCH_CONTEXT_SIZE": "medium",
+        "REASONING_EFFORT": "medium",
+        "OPENAI_API_TIMEOUT": "600000"
+      }
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enable GitHub action to use the same MCP servers as the local environment
- add `.mcp.json` with Playwright, TypeScript LSP, o3 search and Context7 servers
- configure `claude.yml` to load the MCP config and allow the custom tools

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874fcd639d883339ced3e35cadb6268